### PR TITLE
Array type safety

### DIFF
--- a/example/01-json-encode.php
+++ b/example/01-json-encode.php
@@ -1,0 +1,15 @@
+<?php
+use Gt\DataObject\DataObject;
+
+require __DIR__ . "/../vendor/autoload.php";
+
+$obj = (new DataObject())
+	->with("name", "Cody")
+	->with("colour", "orange")
+	->with("food", [
+		"biscuits",
+		"mushrooms",
+		"corn on the cob",
+	]);
+
+echo json_encode($obj), PHP_EOL;

--- a/example/02-json-decode.php
+++ b/example/02-json-decode.php
@@ -3,7 +3,17 @@ use Gt\DataObject\DataObjectBuilder;
 
 require __DIR__ . "/../vendor/autoload.php";
 
-$jsonString = '{"name":"Cody","colour":"orange","food":["biscuits","mushrooms","corn on the cob"]}';
+$jsonString = <<<JSON
+{
+	"name": "Cody",
+	"colour": "orange",
+	"food": [
+		"biscuits",
+		"mushrooms",
+		"corn on the cob"
+	]
+}
+JSON;
 
 $builder = new DataObjectBuilder();
 $obj = $builder->fromObject(json_decode($jsonString));

--- a/example/02-json-decode.php
+++ b/example/02-json-decode.php
@@ -1,0 +1,15 @@
+<?php
+use Gt\DataObject\DataObjectBuilder;
+
+require __DIR__ . "/../vendor/autoload.php";
+
+$jsonString = '{"name":"Cody","colour":"orange","food":["biscuits","mushrooms","corn on the cob"]}';
+
+$builder = new DataObjectBuilder();
+$obj = $builder->fromObject(json_decode($jsonString));
+
+echo "Hello, ",
+	$obj->getString("name"),
+	"! Your favourite food is ",
+	$obj->getArray("food")[0],
+	PHP_EOL;

--- a/example/03-type-casting.php
+++ b/example/03-type-casting.php
@@ -1,0 +1,22 @@
+<?php
+
+use Gt\DataObject\DataObject;
+
+require __DIR__ . "/../vendor/autoload.php";
+
+// Set an object with all string values, similar to a web requests:
+$obj = new DataObject();
+$obj = $obj->with("one", "1");
+$obj = $obj->with("two", "two");
+$obj = $obj->with("pi", "3.14159");
+
+// Automatically cast to int:
+
+$int1 = $obj->getInt("one");
+$int2 = $obj->getInt("two");
+$int3 = $obj->getInt("pi");
+
+echo "One: $int1, two: $int2, three: $int3", PHP_EOL;
+// Outputs: One: 1, two: 0, three: 3
+// Note how the decimal data is lost in the cast to int,
+// but how the original data is not lost.

--- a/example/04-type-safety-arrays.php
+++ b/example/04-type-safety-arrays.php
@@ -1,0 +1,20 @@
+<?php
+
+use Gt\DataObject\DataObject;
+
+require __DIR__ . "/../vendor/autoload.php";
+
+$obj = new DataObject();
+$obj = $obj->with("arrayOfData", [
+	1,
+	2,
+	3.14159,
+]);
+
+echo "The third element in the array is: ",
+	$obj->getArray("arrayOfData", "int")[2], // note the type check of "int"
+	PHP_EOL;
+
+/* Output:
+The third element in the array is: 3
+*/

--- a/src/DataObject.php
+++ b/src/DataObject.php
@@ -114,8 +114,8 @@ class DataObject implements JsonSerializable, TypeSafeGetter {
 	}
 
 	/**
-	 * @param array $array
-	 * @return array
+	 * @param array<mixed> $array
+	 * @return array<mixed>
 	 */
 	private function checkArrayType(array $array, string $type):array {
 		$errorMessage = "";

--- a/test/phpunit/DataObjectTest.php
+++ b/test/phpunit/DataObjectTest.php
@@ -3,9 +3,11 @@ namespace Gt\DataObject\Test;
 
 use DateTime;
 use DateTimeInterface;
+use Error;
 use Gt\DataObject\DataObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Throwable;
 use TypeError;
 
 class DataObjectTest extends TestCase {
@@ -103,6 +105,21 @@ class DataObjectTest extends TestCase {
 	public function testGetStringNull() {
 		$sut = new DataObject();
 		self::assertNull($sut->getString("nothing"));
+	}
+
+	public function testGetStringFromDateTime() {
+		$sut = (new DataObject())
+			->with("dt", new DateTime());
+
+		$exception = null;
+
+		try {
+			$data = $sut->getString("dt");
+		}
+		catch(Throwable $exception) {}
+
+		self::assertInstanceOf(Error::class, $exception);
+		self::assertSame("Object of class DateTime could not be converted to string", $exception->getMessage());
 	}
 
 	public function testGetIntFromString() {
@@ -374,15 +391,20 @@ class DataObjectTest extends TestCase {
 			49997,
 			50000,
 			49999,
-			"PLOP!",
+			"50003",
 			50001,
 		];
 		$sut = (new DataObject())
 			->with("timestamps", $timestampArray);
 
-		self::expectException(TypeError::class);
-		self::expectExceptionMessage("Array index 3 must be of type int, string given");
-		$sut->getArray("timestamps", "int");
+		$array = $sut->getArray("timestamps", "int");
+		foreach($array as $i => $value) {
+			if($i === 3) {
+				self::assertSame(50003, $value);
+			}
+
+			self::assertIsInt($value);
+		}
 	}
 
 	public function testGetArrayFixedTypeFloat() {

--- a/test/phpunit/DataObjectTest.php
+++ b/test/phpunit/DataObjectTest.php
@@ -455,7 +455,7 @@ class DataObjectTest extends TestCase {
 		}
 	}
 
-	public function testGetArrayFixedTypeString_typeErrorWithObject() {
+	public function testGetArrayFixedTypeString_typeErrorWithDateTime() {
 		$wordsArray = [
 			"one",
 			"two",
@@ -465,7 +465,7 @@ class DataObjectTest extends TestCase {
 		];
 		$sut = (new DataObject())
 			->with("words", $wordsArray);
-		self::expectExceptionMessage("Array index 3 must be of type string, DateTime given");
+		self::expectExceptionMessage("Object of class DateTime could not be converted to string");
 		$sut->getArray("words", "string");
 	}
 
@@ -478,7 +478,7 @@ class DataObjectTest extends TestCase {
 			->with("dates", $dateArray);
 		$array = $sut->getArray("dates", DateTimeInterface::class);
 		foreach($array as $i => $value) {
-			self::assertInstanceOf(DateTimeInterface::class, $value);
+			self::assertInstanceOf(DateTime::class, $value);
 		}
 	}
 
@@ -492,9 +492,8 @@ class DataObjectTest extends TestCase {
 		];
 		$sut = (new DataObject())
 			->with("timestamps", $timestampArray);
-		self::expectException(TypeError::class);
-		self::expectExceptionMessage("Array index 2 must be of type int, double given");
-		$sut->getArray("timestamps", "int");
+		$array = $sut->getArray("timestamps", "int");
+		self::assertSame(49999, $array[2]);
 	}
 
 	public function testGetArray_nullableType():void {


### PR DESCRIPTION
This PR makes type checking more consistent when dealing with typed arrays.

If the values can be cast to the requested scalar, they will be cast. Otherwise the appropriate TypeError will be thrown by PHP.